### PR TITLE
Consider arch property of driver definitions

### DIFF
--- a/src/main/groovy/com/github/erdi/gradle/webdriver/repository/DriverUrlNotFoundException.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/repository/DriverUrlNotFoundException.groovy
@@ -21,8 +21,8 @@ class DriverUrlNotFoundException extends Exception {
 
     @SuppressWarnings(['SpaceAfterClosingBrace', 'SpaceBeforeClosingBrace'])
     @Builder
-    private DriverUrlNotFoundException(String name, String version, String platform, Collection<String> bits) {
-        super(/Driver url not found for name: "$name", version regexp: "$version", platform: "$platform", bit: "${bits.join(' or ')}"/)
+    private DriverUrlNotFoundException(String name, String version, String platform, Collection<String> bits, Collection<String> archs) {
+        super(/Driver url not found for name: "$name", version regexp: "$version", platform: "$platform", bit: "${bits.join(' or ')}", arch: "${archs.join(' or ')}"/)
     }
 
 }

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/PluginSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/PluginSpec.groovy
@@ -103,7 +103,8 @@ class PluginSpec extends Specification {
                     platform: DriverUrlsConfiguration.PLATFORMS[operatingSystem],
                     bit: DriverUrlsConfiguration.BITS[arch],
                     version: version,
-                    url: driverZip.toURI().toString()
+                    url: driverZip.toURI().toString(),
+                    arch: DriverUrlsConfiguration.ARCHS[arch]
                 ]
             ]
         )


### PR DESCRIPTION
Apologies if this duplicates work you already had in progress, I saw the comment trail on #34 and figured that the free time hadn't surfaced yet.

There's probably a better way to handle null arch properties. It seems that when that property is omitted it implies x86 or x86_64 (for 32 bit and 64 bit respectively) but given M1 macs have the rosetta emulation layer I didn't think it was worth working out which platforms need to have incompatible architectures blocked. I also didn't allow falling back from aarch64/ARM64 to amd64/X86_64 since the current definitions usually do that implicitly.