### PR TITLE
Upgrade grolifant to 2.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     }
     codenarc("org.codehaus.groovy:groovy-all:3.0.13")
 
-    implementation("org.ysb33r.gradle:grolifant50:1.3.3")
+    implementation("org.ysb33r.gradle:grolifant50:2.0.2")
     implementation("org.apache.maven:maven-artifact:3.8.7")
 
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0") {


### PR DESCRIPTION
Fixes #30 . 
Despite not mentioning it in any changelog the fix for https://gitlab.com/ysb33rOrg/grolifant/-/issues/82 is included in the latest `2.0.2` release for the `org.ysb33r.gradle:grolifant50`. 
I tested this by publishing the plugin to local maven repository.