### PR TITLE
Proposed workaround for #39 - Search for binary file if it isn't in root distribution

### DIFF
--- a/src/main/groovy/com/github/erdi/gradle/webdriver/chrome/ConfigureChromeDriverBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/chrome/ConfigureChromeDriverBinary.groovy
@@ -16,6 +16,7 @@
 package com.github.erdi.gradle.webdriver.chrome
 
 import com.github.erdi.gradle.webdriver.task.ConfigureBinary
+import org.gradle.api.model.ObjectFactory
 
 import javax.inject.Inject
 
@@ -25,8 +26,8 @@ import static com.github.erdi.gradle.webdriver.WebDriverBinaryMetadata.CHROMEDRI
 abstract class ConfigureChromeDriverBinary extends ConfigureBinary {
 
     @Inject
-    ConfigureChromeDriverBinary() {
-        super(CHROMEDRIVER, 'chromedriver')
+    ConfigureChromeDriverBinary(ObjectFactory objectFactory) {
+        super(objectFactory, CHROMEDRIVER, 'chromedriver')
     }
 
 }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/edge/ConfigureEdgeDriverBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/edge/ConfigureEdgeDriverBinary.groovy
@@ -16,6 +16,7 @@
 package com.github.erdi.gradle.webdriver.edge
 
 import com.github.erdi.gradle.webdriver.task.ConfigureBinary
+import org.gradle.api.model.ObjectFactory
 
 import javax.inject.Inject
 
@@ -25,8 +26,8 @@ import static com.github.erdi.gradle.webdriver.WebDriverBinaryMetadata.EDGEDRIVE
 abstract class ConfigureEdgeDriverBinary extends ConfigureBinary {
 
     @Inject
-    ConfigureEdgeDriverBinary() {
-        super(EDGEDRIVER, 'edgedriver')
+    ConfigureEdgeDriverBinary(ObjectFactory objectFactory) {
+        super(objectFactory, EDGEDRIVER, 'edgedriver')
     }
 
 }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/gecko/ConfigureGeckoDriverBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/gecko/ConfigureGeckoDriverBinary.groovy
@@ -16,6 +16,7 @@
 package com.github.erdi.gradle.webdriver.gecko
 
 import com.github.erdi.gradle.webdriver.task.ConfigureBinary
+import org.gradle.api.model.ObjectFactory
 
 import javax.inject.Inject
 
@@ -25,8 +26,8 @@ import static com.github.erdi.gradle.webdriver.WebDriverBinaryMetadata.GECKODRIV
 abstract class ConfigureGeckoDriverBinary extends ConfigureBinary {
 
     @Inject
-    ConfigureGeckoDriverBinary() {
-        super(GECKODRIVER, 'geckodriver')
+    ConfigureGeckoDriverBinary(ObjectFactory objectFactory) {
+        super(objectFactory, GECKODRIVER, 'geckodriver')
     }
 
 }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -70,13 +70,10 @@ abstract class ConfigureBinary extends DefaultTask {
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
         def platformIndependentBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
-        def binaryFile = new File(distributionRoot, platformIndependentBinaryName)
-        if (!binaryFile.exists()) {
-            //Some versions of chromedriver hide the binary deeper, so we traverse the directory to find the binary
-            distributionRoot.traverse(type: FileType.FILES, nameFilter: platformIndependentBinaryName) { file ->
-                binaryFile = file
-            }
-        }
+        def binaryFile = project.objects.fileTree().tap {
+            from(distributionRoot)
+            include("**/$platformIndependentBinaryName")
+        }.singleFile
         def binaryAbsolutePath = binaryFile.absolutePath
         binaryAwares*.setDriverBinaryPathAndVersion(binaryAbsolutePath, versionAndUri.version)
     }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -75,10 +75,10 @@ abstract class ConfigureBinary extends DefaultTask {
         def versionAndUri = new DriverUrlsConfiguration(driverUrlsConfiguration.get().asFile()).versionAndUriFor(downloadSpec())
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
-        def platformIndependentBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
+        def osSpecificBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
         def binaryFile = objectFactory.fileTree().tap {
             from(distributionRoot)
-            include("**/$platformIndependentBinaryName")
+            include("**/$osSpecificBinaryName")
         }.singleFile
         def binaryAbsolutePath = binaryFile.absolutePath
         binaryAwares*.setDriverBinaryPathAndVersion(binaryAbsolutePath, versionAndUri.version)

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -20,6 +20,7 @@ import com.github.erdi.gradle.webdriver.DriverDistributionInstaller
 import com.github.erdi.gradle.webdriver.DriverDownloadSpecification
 import com.github.erdi.gradle.webdriver.WebDriverBinaryMetadata
 import com.github.erdi.gradle.webdriver.repository.DriverUrlsConfiguration
+import groovy.io.FileType
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -69,6 +70,12 @@ abstract class ConfigureBinary extends DefaultTask {
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
         def binaryFile = new File(distributionRoot, operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName))
+        if (!binaryFile.exists()) {
+            //Some versions of chromedriver hide the binary deeper, so we traverse the directory to find the binary
+            distributionRoot.traverse(type: FileType.FILES, nameFilter: webDriverBinaryMetadata.binaryName) { file ->
+                binaryFile = file
+            }
+        }
         def binaryAbsolutePath = binaryFile.absolutePath
         binaryAwares*.setDriverBinaryPathAndVersion(binaryAbsolutePath, versionAndUri.version)
     }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -69,10 +69,11 @@ abstract class ConfigureBinary extends DefaultTask {
         def versionAndUri = new DriverUrlsConfiguration(driverUrlsConfiguration.get().asFile()).versionAndUriFor(downloadSpec())
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
-        def binaryFile = new File(distributionRoot, operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName))
+        def platformIndependentBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
+        def binaryFile = new File(distributionRoot, platformIndependentBinaryName)
         if (!binaryFile.exists()) {
             //Some versions of chromedriver hide the binary deeper, so we traverse the directory to find the binary
-            distributionRoot.traverse(type: FileType.FILES, nameFilter: webDriverBinaryMetadata.binaryName) { file ->
+            distributionRoot.traverse(type: FileType.FILES, nameFilter: platformIndependentBinaryName) { file ->
                 binaryFile = file
             }
         }

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -20,15 +20,17 @@ import com.github.erdi.gradle.webdriver.DriverDistributionInstaller
 import com.github.erdi.gradle.webdriver.DriverDownloadSpecification
 import com.github.erdi.gradle.webdriver.WebDriverBinaryMetadata
 import com.github.erdi.gradle.webdriver.repository.DriverUrlsConfiguration
-import groovy.io.FileType
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.resources.TextResource
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.OperatingSystem
 import org.ysb33r.grolifant.api.core.OperatingSystem.Arch
+
+import javax.inject.Inject
 
 abstract class ConfigureBinary extends DefaultTask {
 
@@ -39,7 +41,11 @@ abstract class ConfigureBinary extends DefaultTask {
     @Internal
     final WebDriverBinaryMetadata webDriverBinaryMetadata
 
-    protected ConfigureBinary(WebDriverBinaryMetadata webDriverBinaryMetadata, String driverName) {
+    private final ObjectFactory objectFactory
+
+    @Inject
+    protected ConfigureBinary(ObjectFactory objectFactory, WebDriverBinaryMetadata webDriverBinaryMetadata, String driverName) {
+        this.objectFactory = objectFactory
         this.webDriverBinaryMetadata = webDriverBinaryMetadata
         this.driverName = driverName
         onlyIf { versionConfigured }
@@ -70,7 +76,7 @@ abstract class ConfigureBinary extends DefaultTask {
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
         def platformIndependentBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
-        def binaryFile = project.objects.fileTree().tap {
+        def binaryFile = objectFactory.fileTree().tap {
             from(distributionRoot)
             include("**/$platformIndependentBinaryName")
         }.singleFile


### PR DESCRIPTION
Per [Issue 39](https://github.com/erdi/webdriver-binaries-gradle-plugin/issues/39), it seemed sensible to search through a given driver distribution's subdirectories for the binary file. This is a somewhat crude way to do it, but it seems to locate the driver path well enough.

This will probably all be obviated by [Selenium Manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/), but this may provide a short-term fix for anyone using this plugin.

One other problem I'm having in my project at the moment is that, using a local build off of this fork, I get this error when launching tests:
```
org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: unknown error: cannot find Chrome binary 
```

While my Chrome version has updated to 115, it still seems to be at the same old default location. Not sure if the Chrome team has somehow changed the expectation for the default binary to be the new Chrome for Testing distro or what. The workaround suggested in [this SO post](https://stackoverflow.com/questions/50138615/webdriverexception-unknown-error-cannot-find-chrome-binary-error-with-selenium) works well enough:
```
    def capabilities = new ChromeOptions()
    capabilities.setBinary(new File('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'))
```

In any event, I don't think it's necessarily a problem for this Gradle plugin to solve, since configuring `ChromeOptions` and the like is more of a problem for consumers. Just noting it here for anyone who may encounter further difficulties down the road.