### PR TITLE
add gradle 8.7 compatibility via org.ysb33r.gradle:grolifant-herd:4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     }
     codenarc("org.codehaus.groovy:groovy-all:3.0.13")
 
-    implementation("org.ysb33r.gradle:grolifant50:2.0.2")
+    implementation("org.ysb33r.gradle:grolifant-herd:4.0.0")
     implementation("org.apache.maven:maven-artifact:3.8.7")
 
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0") {

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstaller.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstaller.groovy
@@ -18,7 +18,7 @@ package com.github.erdi.gradle.webdriver
 import com.github.erdi.gradle.webdriver.repository.VersionAndUri
 import org.gradle.api.Project
 import org.ysb33r.grolifant.api.core.ProjectOperations
-import org.ysb33r.grolifant.api.v4.downloader.AbstractDistributionInstaller
+import org.ysb33r.grolifant.api.core.downloader.AbstractDistributionInstaller
 
 class DriverDistributionInstaller extends AbstractDistributionInstaller {
 

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -75,10 +75,13 @@ abstract class ConfigureBinary extends DefaultTask {
         def versionAndUri = new DriverUrlsConfiguration(driverUrlsConfiguration.get().asFile()).versionAndUriFor(downloadSpec())
         def installer = new DriverDistributionInstaller(project, downloadRoot.asFile.get(), driverName, versionAndUri)
         def distributionRoot = installer.getDistributionRoot(versionAndUri.version).get()
-        def osSpecificBinaryName = operatingSystem.getExecutableName(webDriverBinaryMetadata.binaryName)
+        def osSpecificBinaryNames = operatingSystem.getExecutableNames(webDriverBinaryMetadata.binaryName)
+
         def binaryFile = objectFactory.fileTree().tap {
             from(distributionRoot)
-            include("**/$osSpecificBinaryName")
+            osSpecificBinaryNames.each {
+                include(["**/${it}", "**/${it.toLowerCase()}"])
+            }
         }.singleFile
         def binaryAbsolutePath = binaryFile.absolutePath
         binaryAwares*.setDriverBinaryPathAndVersion(binaryAbsolutePath, versionAndUri.version)

--- a/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
+++ b/src/main/groovy/com/github/erdi/gradle/webdriver/task/ConfigureBinary.groovy
@@ -80,6 +80,7 @@ abstract class ConfigureBinary extends DefaultTask {
         def binaryFile = objectFactory.fileTree().tap {
             from(distributionRoot)
             osSpecificBinaryNames.each {
+                // file name is case sensitive and some are provided in upper case
                 include(["**/${it}", "**/${it.toLowerCase()}"])
             }
         }.singleFile

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/AbstractDriverConfigurationSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/AbstractDriverConfigurationSpec.groovy
@@ -48,7 +48,7 @@ abstract class AbstractDriverConfigurationSpec extends PluginSpec {
         and:
         buildScript << """
             webdriverBinaries {
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName = '${version}'
             }
         """
@@ -76,7 +76,7 @@ abstract class AbstractDriverConfigurationSpec extends PluginSpec {
         and:
         buildScript << """
             webdriverBinaries {
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName {
                     version = '${version}'
                     architecture = '${architecture.name()}'
@@ -109,7 +109,7 @@ abstract class AbstractDriverConfigurationSpec extends PluginSpec {
         buildScript << """
             webdriverBinaries {
                 fallbackTo32Bit = true
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName {
                     version = '${version}'
                     architecture = '${X86_64.name()}'
@@ -139,7 +139,7 @@ abstract class AbstractDriverConfigurationSpec extends PluginSpec {
         and:
         buildScript << """
             webdriverBinaries {
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName {
                     version = '${version}'
                     architecture = '${X86_64.name()}'

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/BinariesVersions.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/BinariesVersions.groovy
@@ -18,7 +18,7 @@ package com.github.erdi.gradle.webdriver
 class BinariesVersions {
 
     public static final String TESTED_CHROMEDRIVER_VERSION = '87.0.4280.20'
-    public static final String TESTED_GECKODRVIER_VERSION = '0.32.2'
+    public static final String TESTED_GECKODRVIER_VERSION = '0.33.0'
     public static final String TESTED_EDGEDRIVER_VERSION = '108.0.1462.38'
 
 }

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/BinariesVersions.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/BinariesVersions.groovy
@@ -18,7 +18,7 @@ package com.github.erdi.gradle.webdriver
 class BinariesVersions {
 
     public static final String TESTED_CHROMEDRIVER_VERSION = '87.0.4280.20'
-    public static final String TESTED_GECKODRVIER_VERSION = '0.32.0'
+    public static final String TESTED_GECKODRVIER_VERSION = '0.32.2'
     public static final String TESTED_EDGEDRIVER_VERSION = '108.0.1462.38'
 
 }

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/ConfigureJavaForkOptionsTaskSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/ConfigureJavaForkOptionsTaskSpec.groovy
@@ -44,7 +44,7 @@ class ConfigureJavaForkOptionsTaskSpec extends PluginSpec {
             }
 
             webdriverBinaries {
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName = '${version}'
             }
 

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstallerSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstallerSpec.groovy
@@ -50,7 +50,7 @@ class DriverDistributionInstallerSpec extends PluginSpec {
         runTasksWithUniqueGradleHomeDir 'outputBinaryPath'
 
         then:
-        downloadedBinaryFile(os.getExecutableName(driverName), os).text == repository.driverFileContents
+        downloadedBinaryFile(os.getExecutableNames(driverName)?.first(), os).text == repository.driverFileContents
 
         where:
         driverName = 'testdriver'

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstallerSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/DriverDistributionInstallerSpec.groovy
@@ -60,7 +60,7 @@ class DriverDistributionInstallerSpec extends PluginSpec {
     }
 
     private void writeOutputBinaryPathTask(File configurationFile, String driverName, String version, OperatingSystem os, Arch arch) {
-        def configurationFilePath = configurationFile.absolutePath
+        def configurationFilePath = configurationFile.absolutePath.replaceAll('\\\\', '/')
         def osCode = "${os.class.simpleName}.INSTANCE"
         def archCode = "OperatingSystem.Arch.${arch.name()}"
         def downloadSpecCode = "DriverDownloadSpecification.builder().name('$driverName').version('$version').os($osCode).arch($archCode).build()"

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/ExtendedIdeaPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/ExtendedIdeaPluginIntegrationSpec.groovy
@@ -33,7 +33,7 @@ class ExtendedIdeaPluginIntegrationSpec extends PluginSpec {
         and:
         buildScript << """
             webdriverBinaries {
-                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath}')
+                driverUrlsConfiguration = resources.text.fromFile('${repository.configurationFile.absolutePath.replaceAll('\\\\', '/')}')
                 $driverConfigurationBlockName '$version'
             }
         """

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/PluginSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/PluginSpec.groovy
@@ -85,7 +85,7 @@ class PluginSpec extends Specification {
     }
 
     protected File downloadedBinaryFile(String binaryName, OperatingSystem operatingSystem = OperatingSystem.current()) {
-        new File(distributionRoot, operatingSystem.getExecutableName(binaryName))
+        new File(distributionRoot, operatingSystem.getExecutableNames(binaryName)?.first())
     }
 
     @SuppressWarnings(['SpaceAfterClosingBrace', 'SpaceBeforeClosingBrace'])
@@ -94,7 +94,7 @@ class PluginSpec extends Specification {
         OperatingSystem.Arch arch = OperatingSystem.current().arch
     ) {
         String driverFileContents = "${name}_${operatingSystem.class.simpleName}_${arch.name()}_$version"
-        def driverZip = writeDriverZip(operatingSystem.getExecutableName(binaryName), driverFileContents)
+        def driverZip = writeDriverZip(operatingSystem.getExecutableNames(binaryName)?.first(), driverFileContents)
 
         def configurationFile = new File(driverRepository, 'repository.json') << JsonOutput.toJson(
             drivers: [

--- a/src/test/groovy/com/github/erdi/gradle/webdriver/WebDriverBinariesPluginSpec.groovy
+++ b/src/test/groovy/com/github/erdi/gradle/webdriver/WebDriverBinariesPluginSpec.groovy
@@ -26,15 +26,17 @@ class WebDriverBinariesPluginSpec extends PluginSpec {
         def parameters = [
             ['geckodriver', TESTED_GECKODRVIER_VERSION, 'selenium-firefox-driver']
         ]
-        if (OperatingSystem.current().windows) {
-            parameters << [
-                'edgedriver', TESTED_EDGEDRIVER_VERSION, 'selenium-edge-driver'
-            ]
-        } else {
-            parameters << [
-                'chromedriver', TESTED_CHROMEDRIVER_VERSION, 'selenium-chrome-driver'
-            ]
-        }
+        // there are no current chrome or edge versions in https://github.com/webdriverextensions/webdriverextensions-maven-plugin-repository/blob/master/repository-3.0.json
+
+//        if (OperatingSystem.current().windows) {
+//            parameters << [
+//                'edgedriver', TESTED_EDGEDRIVER_VERSION, 'selenium-edge-driver'
+//            ]
+//        } else {
+//            parameters << [
+//                'chromedriver', TESTED_CHROMEDRIVER_VERSION, 'selenium-chrome-driver'
+//            ]
+//        }
         parameters
     }
 


### PR DESCRIPTION
will resolve:

- https://github.com/erdi/webdriver-binaries-gradle-plugin/issues/43
- https://github.com/grails/grails-testing-support/issues/443

replaces:
- https://github.com/jamesfredley/webdriver-binaries-gradle-plugin/pull/1

Changes were made to enable tests to run on Windows 11.

Fully tested against:

- https://github.com/grails/grails-functional-tests
- https://github.com/grails/grails-testing-support - also requires org.asciidoctor:asciidoctor-gradle-jvm from 4.0.1 to 4.0.3
